### PR TITLE
fix Id::Num

### DIFF
--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -22,6 +22,7 @@ impl Id {
             &Value::String(ref val) => Ok(Id::Str(val.to_string())),
             &Value::I64(val) => Ok(Id::Num(val)),
             &Value::Null => Ok(Id::Null),
+            &Value::U64(val) => Ok(Id::Num(val as i64)),
             _ => Err(Error::invalid_request()),
         }
     }


### PR DESCRIPTION
for some reason it decides to use U64 instead of I64 from time to time, this might not be optimal the optimal solution but it works as a patch.