### PR TITLE
Expose fields in Request, Notification, Success, and Error

### DIFF
--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -152,12 +152,23 @@ pub struct Request {
     /// JSON-RPC protocol version (always "2.0")
     jsonrpc: String,
     /// Name of the method to be invoked
-    method: String,
+    pub method: String,
     /// Parameters to be used during the invocation of the method
     #[serde(skip_serializing_if = "Option::is_none")]
-    params: Option<Params>,
+    pub params: Option<Params>,
     /// Client-established identifier for this request
-    id: Id,
+    pub id: Id,
+}
+
+impl Request {
+    /// Gets the JSON-RPC protocol version
+    ///
+    /// # Returns
+    ///
+    /// The protocol version string ("2.0") or None if not available
+    pub fn get_version(&self) -> &str {
+        &self.version
+    }
 }
 
 /// JSON-RPC 2.0 Notification object
@@ -169,10 +180,21 @@ pub struct Notification {
     /// JSON-RPC protocol version (always "2.0")
     jsonrpc: String,
     /// Name of the method to be invoked
-    method: String,
+    pub method: String,
     /// Parameters to be used during the invocation of the method
     #[serde(skip_serializing_if = "Option::is_none")]
-    params: Option<Params>,
+    pub params: Option<Params>,
+}
+
+impl Notification {
+    /// Gets the JSON-RPC protocol version
+    ///
+    /// # Returns
+    ///
+    /// The protocol version string ("2.0") or None if not available
+    pub fn get_version(&self) -> &str {
+        &self.version
+    }
 }
 
 /// JSON-RPC 2.0 Success Response object
@@ -184,9 +206,20 @@ pub struct Success {
     /// JSON-RPC protocol version (always "2.0")
     jsonrpc: String,
     /// The result of the method call
-    result: Value,
+    pub result: Value,
     /// Client-established identifier matching the request
-    id: Id,
+    pub id: Id,
+}
+
+impl Success {
+    /// Gets the JSON-RPC protocol version
+    ///
+    /// # Returns
+    ///
+    /// The protocol version string ("2.0") or None if not available
+    pub fn get_version(&self) -> &str {
+        &self.version
+    }
 }
 
 /// JSON-RPC 2.0 Error Response object
@@ -198,9 +231,20 @@ pub struct Error {
     /// JSON-RPC protocol version (always "2.0")
     jsonrpc: String,
     /// The error that occurred
-    error: RpcError,
+    pub error: RpcError,
     /// Client-established identifier matching the request
-    id: Id,
+    pub id: Id,
+}
+
+impl Error {
+    /// Gets the JSON-RPC protocol version
+    ///
+    /// # Returns
+    ///
+    /// The protocol version string ("2.0") or None if not available
+    pub fn get_version(&self) -> &str {
+        &self.version
+    }
 }
 
 /// JSON-RPC 2.0 Request object and Response object

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -142,6 +142,25 @@ impl From<Map<String, Value>> for Params {
     }
 }
 
+impl From<Params> for Value {
+    /// Converts a Params to a serde_json Value
+    ///
+    /// # Arguments
+    ///
+    /// * `val` - The Params to convert
+    ///
+    /// # Returns
+    ///
+    /// A new serde_json Value
+    fn from(val: Params) -> Self {
+        match val {
+            Params::Array(values) => values.into(),
+            Params::Map(map) => map.into(),
+            Params::None(()) => Value::Null
+        }
+    }
+}
+
 /// JSON-RPC 2.0 Request object
 ///
 /// A request object represents a call to a method on the server.


### PR DESCRIPTION
Hello, how are you doing?

I really like this crate, it's exactly what I need, a small and light specification of jsonrpc. The goal of this pull request is to make the crate more ergonomic, since I feel like it is unnecessarily cumbersome at times, mostly due to needless privatization of struct fields.

Right now, it works great if all you want to do is serialize some jsonrpc to a `serde_json` `Value`. However, doing the opposite is (unnecessarily) cumbersome. Consider the following:

```rust
use jsonrpc_lite::JsonRpc;

fn handle_rpc(jsonrpc: JsonRpc) {
    match jsonrpc {
        JsonRpc::Request(request) => todo!(),
        JsonRpc::Notification(notification) => todo!(),
        JsonRpc::Success(success) => todo!(),
        JsonRpc::Error(error) => todo!(),
    }
}
```

Let's say I want to handle each type of jsonrpc object in a specific way. If I want to, say, inspect the method, which is only (and always) a thing in requests and notifications, you'd expect that the pattern matching would take care of that, like this:

```rust
use jsonrpc_lite::JsonRpc;

fn handle_rpc(jsonrpc: JsonRpc) {
    match jsonrpc {
        JsonRpc::Request(request) => {
            let method = request.method;
            do_stuff_with_method(method);
        },
        JsonRpc::Notification(notification) => todo!(),
        JsonRpc::Success(success) => todo!(),
        JsonRpc::Error(error) => todo!(),
    }
}
```

But since the fields of a `Request` are private, I have to do this ugly hack instead:

```rust
use jsonrpc_lite::JsonRpc;

fn handle_rpc(jsonrpc: JsonRpc) {
    match &jsonrpc {
        JsonRpc::Request(request) => {
            let method = jsonrpc.get_method().unwrap().to_string();
            do_stuff_with_method(method);
        },
        JsonRpc::Notification(notification) => todo!(),
        JsonRpc::Success(success) => todo!(),
        JsonRpc::Error(error) => todo!(),
    }
}
```

Which not only is much less ergonomic, but it also results in the `String` being copied, and the loss of move semantics niceness. The situation is even worse for `Params`:

```rust
use jsonrpc_lite::{JsonRpc, Params};
use serde_json::Value;

fn handle_rpc(jsonrpc: JsonRpc) {
    match &jsonrpc {
        JsonRpc::Request(request) => {
            let method = method.unwrap().to_string();
            let value: Value = jsonrpc.get_params().map(|params| match params {
                Params::Array(values) => values.into(),
                Params::Map(map) => map.into(),
                Params::None(()) => Value::Null
            });

            do_stuff_with_method_and_json_value(method, value);
        },
        JsonRpc::Notification(notification) => todo!(),
        JsonRpc::Success(success) => todo!(),
        JsonRpc::Error(error) => todo!(),
    }
}
```

This not only is way too verbose and unergonomic, it also clones a (potentially huge) `Params` value. This would be much more pleasant and efficient:


```rust
use jsonrpc_lite::{JsonRpc, Params};
use serde_json::Value;

fn handle_rpc(jsonrpc: JsonRpc) {
    match jsonrpc {
        JsonRpc::Request(request) => {
            let method = request.method;
            let value: Value = request.params.map(Into::into);

            do_stuff_with_method_and_json_value(method, value);
        },
        JsonRpc::Notification(notification) => todo!(),
        JsonRpc::Success(success) => todo!(),
        JsonRpc::Error(error) => todo!(),
    }
}
```